### PR TITLE
fix :: svg, path 커스텀 스타일 props type 변경 #27

### DIFF
--- a/packages/assets/src/icons/style.ts
+++ b/packages/assets/src/icons/style.ts
@@ -1,10 +1,10 @@
-import styled, { RuleSet } from "styled-components";
+import styled, { type Interpolation } from "styled-components";
 
-export const StyledSvg = styled.svg<{ $svgStyle: RuleSet }>`
+export const StyledSvg = styled.svg<{ $svgStyle: Interpolation<object> }>`
   ${({ $svgStyle }) => $svgStyle}
 `;
 
-export const StyledPath = styled.path<{ color: string, $pathStyle: RuleSet }>`
+export const StyledPath = styled.path<{ color: string, $pathStyle: Interpolation<object> }>`
   fill: ${({ color }) => color};
   ${({ $pathStyle }) => $pathStyle}
 `;

--- a/packages/assets/src/icons/type.ts
+++ b/packages/assets/src/icons/type.ts
@@ -1,4 +1,4 @@
-import { RuleSet } from "styled-components";
+import { type Interpolation } from "styled-components";
 
 export interface StaticIconProps {
   size?: number;
@@ -6,6 +6,6 @@ export interface StaticIconProps {
 
 export interface IconProps extends StaticIconProps {
   color?: string;
-  $svgStyle?: RuleSet;
-  $pathStyle?: RuleSet;
+  $svgStyle?: Interpolation<object>;
+  $pathStyle?: Interpolation<object>;
 }


### PR DESCRIPTION
한 일 📚
- css를 사용하는 것이 코드도 길어지고 불편하다는 의견이 있었음
   -> style을 객체 형식으로 보낼 수 있게 만들었습니다.
<img width="341" alt="스크린샷 2024-11-12 오전 10 09 35" src="https://github.com/user-attachments/assets/2d2d6788-3e09-4e3d-b942-d21c869f0808">
